### PR TITLE
fix: handle empty string in kube_exec_auth_role_arn and add hostname override

### DIFF
--- a/src/helm-variables.tf
+++ b/src/helm-variables.tf
@@ -69,4 +69,11 @@ variable "hostname_template" {
     The `format()` string to use to generate the hostname via `format(var.hostname_template, var.tenant, var.stage, var.environment)`"
     Typically something like `"echo.%[3]v.%[2]v.example.com"`.
     EOT
+  default     = ""
+}
+
+variable "hostname" {
+  type        = string
+  description = "Hostname override. When set, this takes precedence over hostname_template."
+  default     = ""
 }

--- a/src/main.tf
+++ b/src/main.tf
@@ -2,7 +2,9 @@ locals {
   ingress_nginx_enabled = var.ingress_type == "nginx" ? true : false
   ingress_alb_enabled   = var.ingress_type == "alb" ? true : false
 
-  hostname = module.this.enabled ? format(var.hostname_template, var.tenant, var.stage, var.environment) : null
+  hostname = module.this.enabled ? (
+    var.hostname != "" ? var.hostname : format(var.hostname_template, var.tenant, var.stage, var.environment)
+  ) : null
 }
 
 module "echo_server" {

--- a/src/provider-helm.tf
+++ b/src/provider-helm.tf
@@ -133,8 +133,9 @@ locals {
     "--profile", var.kube_exec_auth_aws_profile
   ] : []
 
+  kube_exec_auth_role_arn = var.kube_exec_auth_role_arn != "" ? var.kube_exec_auth_role_arn : try(module.iam_roles.terraform_role_arn, "")
   exec_role = local.kube_exec_auth_enabled && var.kube_exec_auth_role_arn_enabled ? [
-    "--role-arn", coalesce(var.kube_exec_auth_role_arn, module.iam_roles.terraform_role_arn)
+    "--role-arn", local.kube_exec_auth_role_arn
   ] : []
 
   # Provide dummy configuration for the case where the EKS cluster is not available.


### PR DESCRIPTION
## What
- Fix handling of empty string for `kube_exec_auth_role_arn` variable in provider-helm.tf
- Add `hostname` variable to override `hostname_template`

## Why

### kube_exec_auth_role_arn fix
`coalesce()` only skips null values, not empty strings. When `kube_exec_auth_role_arn` is set to an empty string and `kube_exec_auth_role_arn_enabled` is false, the evaluation still fails.

### hostname override
Allows explicit hostname configuration when the hostname_template format string is not flexible enough for the use case.

## References
- Context from customer implementations